### PR TITLE
Fix link to LCM technical paper in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **A terminal-based AI coding agent with Lossless Context Management.** 
 
-This is a research preview from Voltropy. For full details, read the [LCM technical paper](papers.voltropy.com/LCM).
+This is a research preview from Voltropy. For full details, read the [LCM technical paper](https://papers.voltropy.com/LCM).
 
 ---
 ## What is Volt?


### PR DESCRIPTION
### **User description**
Updated the link to the LCM technical paper in the README.

### What does this PR do?

### How did you verify your code works?


___

### **PR Type**
Bug fix


___

### **Description**
- Added missing `https://` protocol to LCM paper link

- Ensures proper URL formatting in README documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README.md<br/>Broken Link"] -- "Add https://<br/>protocol" --> B["README.md<br/>Fixed Link"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add https protocol to LCM paper link</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Fixed malformed URL by adding <code>https://</code> protocol prefix<br> <li> Changed link from <code>papers.voltropy.com/LCM</code> to <br><code>https://papers.voltropy.com/LCM</code><br> <li> Ensures the LCM technical paper link is clickable and properly <br>formatted</ul>


</details>


  </td>
  <td><a href="https://github.com/voltropy/volt/pull/2/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

