### PR TITLE
fix: replace Blacksmith CI runners with GitHub-hosted ubuntu-latest

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   update-docs:
     if: github.repository == 'sst/voltcode'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-duplicates:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/duplicate-prs.yml
+++ b/.github/workflows/duplicate-prs.yml
@@ -17,7 +17,7 @@ jobs:
       github.event.pull_request.user.login != 'adamdotdevin' &&
       github.event.pull_request.user.login != 'iamdavidhill' &&
       github.event.pull_request.user.login != 'voltcode-agent[bot]'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   generate:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/nix-desktop.yml
+++ b/.github/workflows/nix-desktop.yml
@@ -26,8 +26,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - blacksmith-4vcpu-ubuntu-2404
-          - blacksmith-4vcpu-ubuntu-2404-arm
+          - ubuntu-latest
+          - ubuntu-latest-arm
           - macos-15-intel
           - macos-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nix-desktop.yml
+++ b/.github/workflows/nix-desktop.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - ubuntu-latest-arm
+          - ubuntu-24.04-arm
           - macos-15-intel
           - macos-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   notify:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Send nicely-formatted embed to Discord
         uses: SethCohen/github-releases-to-discord@v1

--- a/.github/workflows/publish-github-action.yml
+++ b/.github/workflows/publish-github-action.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release-github-action.yml
+++ b/.github/workflows/release-github-action.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -10,7 +10,7 @@ jobs:
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/review') &&
       contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -10,7 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   stats:
     if: github.repository == 'anomalyco/voltcode'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
 

--- a/.github/workflows/sync-zed-extension.yml
+++ b/.github/workflows/sync-zed-extension.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   zed:
     name: Release Zed Extension
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   triage:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   typecheck:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/update-nix-hashes.yml
+++ b/.github/workflows/update-nix-hashes.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   update-node-modules-hashes:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     env:
       TITLE: node_modules hashes
 

--- a/.github/workflows/update-nix-hashes.yml
+++ b/.github/workflows/update-nix-hashes.yml
@@ -11,6 +11,8 @@ on:
       - "package.json"
       - "packages/*/package.json"
       - "flake.lock"
+      - "flake.nix"
+      - "nix/node_modules.nix"
       - ".github/workflows/update-nix-hashes.yml"
   pull_request:
     paths:
@@ -18,6 +20,8 @@ on:
       - "package.json"
       - "packages/*/package.json"
       - "flake.lock"
+      - "flake.nix"
+      - "nix/node_modules.nix"
       - ".github/workflows/update-nix-hashes.yml"
 
 jobs:

--- a/.github/workflows/voltcode.yml
+++ b/.github/workflows/voltcode.yml
@@ -13,7 +13,7 @@ jobs:
       startsWith(github.event.comment.body, '/oc') ||
       contains(github.event.comment.body, ' /voltcode') ||
       startsWith(github.event.comment.body, '/voltcode')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## What

Replaces all Blacksmith runner references with standard GitHub-hosted runners so CI actually executes.

## Why

Every CI workflow in this repo uses `blacksmith-4vcpu-ubuntu-2404` — a paid third-party runner service that the upstream OpenCode project used. Martian-Engineering doesn't have a Blacksmith subscription, so all jobs queue forever and never run. This is why no CI workflow has ever completed on this fork.

## Changes

- Replace `blacksmith-4vcpu-ubuntu-2404` with `ubuntu-latest` across 17 workflow files
- Fix `blacksmith-4vcpu-ubuntu-2404-arm` → `ubuntu-24.04-arm` in `nix-desktop.yml` (GitHub doesn't offer `ubuntu-latest-arm`)

## Testing

- `bun typecheck` passes
- Changes are YAML-only, no runtime code touched
- Reviewed by worker: confirmed no Blacksmith-specific features (caching, setup actions) were in use — the label was a pure drop-in replacement