### PR TITLE
fix: show permission/question prompts in task tree viewer

### DIFF
--- a/packages/voltcode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/voltcode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1242,7 +1242,17 @@ export function Session() {
       >
         <Switch>
           <Match when={taskTreeVisible() && !session()?.parentID}>
-            <TaskTreePane sessionID={route.sessionID} showDevInfo={args.dev ?? false} />
+            <box flexDirection="column" flexGrow={1}>
+              <TaskTreePane sessionID={route.sessionID} showDevInfo={args.dev ?? false} />
+              <box flexShrink={0}>
+                <Show when={permissions().length > 0}>
+                  <PermissionPrompt request={permissions()[0]} />
+                </Show>
+                <Show when={permissions().length === 0 && questions().length > 0}>
+                  <QuestionPrompt request={questions()[0]} />
+                </Show>
+              </box>
+            </box>
           </Match>
           <Match when={true}>
             <box flexDirection="row">


### PR DESCRIPTION
## Summary
- When the task tree view is active, permission requests from sub-tasks were invisible because the `TaskTreePane` completely replaced the main session view (which contained the `PermissionPrompt`)
- This wraps the `TaskTreePane` in a flex column and renders permission/question prompts below it, matching the same pattern used in the main session view
- Users can now respond to permission requests without switching out of the task tree view

Fixes #13

## Test plan
- [ ] Run `bun dev`, trigger a sub-task that requires a permission (e.g., a bash command), switch to the task tree view, and verify the permission prompt appears at the bottom
- [ ] Verify the permission prompt works correctly (allow once / allow always / reject)
- [ ] Verify question prompts also appear in the task tree view when there are no pending permissions
- [ ] Verify the task tree still renders correctly with no pending permissions (no extra whitespace or layout shifts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)